### PR TITLE
Fix concurrency issues that happens when setting internal promise reference in updateToken method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -476,7 +476,7 @@ export class KeycloakClient implements KeycloakInstance {
             this.onAuthRefreshSuccess && this.onAuthRefreshSuccess();
 
             for (
-              var p = this.refreshQueue.pop();
+              let p = this.refreshQueue.pop();
               p != null;
               p = this.refreshQueue.pop()
             ) {
@@ -490,7 +490,7 @@ export class KeycloakClient implements KeycloakInstance {
           this.onAuthRefreshError && this.onAuthRefreshError();
 
           for (
-            var p = this.refreshQueue.pop();
+            let p = this.refreshQueue.pop();
             p != null;
             p = this.refreshQueue.pop()
           ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,8 @@ export interface FetchTokenResponse {
   id_token: string | null;
 
   refresh_token: string | null;
+
+  error: string | null;
 }
 
 export interface KeycloakAdapterConstructor {

--- a/src/utils/deferred.ts
+++ b/src/utils/deferred.ts
@@ -1,0 +1,16 @@
+export default class Deferred<T> {
+  private promise: Promise<T>;
+  public resolve!: (value: T | PromiseLike<T>) => void;
+  public reject!: (reason?: any) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.reject = reject;
+      this.resolve = resolve;
+    });
+  }
+
+  public getPromise(): Promise<T> {
+    return this.promise;
+  }
+}


### PR DESCRIPTION
## Description
Fix concurrency issues that happens when setting internal promise reference in `updateToken` method and updated the code to reflect the keycloak js adapter one, as just clearing the token when we have a 400 and also not emitting a `onAuthRefreshSuccess` when it fails. Ref.: https://github.com/keycloak/keycloak/blob/13.0.0/adapters/oidc/js/src/main/resources/keycloak.js#L620

Fixes #5 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
