### PR TITLE
fix: generatePkceChallenge

### DIFF
--- a/src/__tests__/uuid.spec.ts
+++ b/src/__tests__/uuid.spec.ts
@@ -1,0 +1,18 @@
+import { generatePkceChallenge, generateCodeVerifier } from '../utils/uuid';
+
+describe('utils', () => {
+  describe('uuid', () => {
+    describe('generatePkceChallenge', () => {
+      it('should generate a pkce challenge', () => {
+        // Arrange
+        const codeVerifier = generateCodeVerifier(96);
+
+        // Act
+        const pkceChallenge = generatePkceChallenge('S256', codeVerifier);
+
+        // Assert
+        expect(pkceChallenge.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -44,9 +44,8 @@ export function generatePkceChallenge(
     // The use of the "plain" method is considered insecure and therefore not supported.
     case 'S256':
       // hash codeVerifier, then encode as url-safe base64 without padding
-      const hashBytes = sha256.arrayBuffer(codeVerifier);
-      // new Uint8Array(sha256_imported.arrayBuffer(codeVerifier));
-      const encodedHash = fromByteArray(hashBytes as Uint8Array)
+      const hashBytes = new Uint8Array(sha256.arrayBuffer(codeVerifier));
+      const encodedHash = fromByteArray(hashBytes)
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/\=/g, '');


### PR DESCRIPTION
## Description
the hashBytes variable was an arrayBuffer and not the expected Uint8Array which resulted in an empty string after calling `fromByteArray(hashBytes)`

Fixes #8 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added a jest unit test to verify `generatePkceChallenge`
- [x] In my react-native app we configured pkceMethod and after this fix keycloak does not crash because of a missing pkceChallenge when we force this flow in the keycloak console

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
